### PR TITLE
Fix Windows path handling in theme loading

### DIFF
--- a/src/resumy/resumy.py
+++ b/src/resumy/resumy.py
@@ -52,10 +52,10 @@ def create_resume(config: Yaml,
                   metadata: DocumentMetadata) -> None:
     # 1. Retrieve theme
     env = jinja2.Environment(
-        loader=jinja2.FileSystemLoader('/'),
+        loader=jinja2.FileSystemLoader(theme_path),
     )
     try:
-        template = env.get_template(f'{theme_path}/theme.html')
+        template = env.get_template('theme.html')
     except jinja2.exceptions.TemplateNotFound as err:
         raise IOError(f"No such file or directory: '{err}'")
 


### PR DESCRIPTION
This commit addresses an issue with path handling in the create_resume function. The fix involves updating the Jinja2 environment loader to use the `theme_path` directly and removing the forward slashes. This ensures cross-platform compatibility, particularly improving the tool's usability on Windows systems.